### PR TITLE
Fix bug on page change; Allow user to use their own TR tags

### DIFF
--- a/vendor/assets/javascripts/osom-tables.js
+++ b/vendor/assets/javascripts/osom-tables.js
@@ -48,7 +48,7 @@
 
     $.ajax(url, {
       success: function(new_content) {
-        container.html(new_content);
+        container.replaceWith(new_content);
       },
       complete: function() {
         container.removeClass('loading');


### PR DESCRIPTION
The bug on page change is that, when you change pages, it creates an extra <div class="osom-table:> every time; a simple replaceWith instead of html fixes it.

The other change is larger; at the moment, you can't supply your own <tr> tags in your head ... or body ... calls. In our case, we needed to set custom classes on a per-row basis. This change detects if you have supplied your on <tr> tags, and if so, uses your html verbatim; otherwise, it wraps your html in a <tr> as before, so existing code can remain the same.

My apologies for the lack of new tests; if it helps at all, we are using these changes right now and they are working for us.
